### PR TITLE
Add support for positional arguments.

### DIFF
--- a/libs/sysplugins/smarty_internal_compilebase.php
+++ b/libs/sysplugins/smarty_internal_compilebase.php
@@ -86,8 +86,9 @@ abstract class Smarty_Internal_CompileBase
                 } elseif (isset($this->shorttag_order[ $key ])) {
                     $_indexed_attr[ $this->shorttag_order[ $key ] ] = $mixed;
                 } else {
-                    // too many shorthands
-                    $compiler->trigger_template_error('too many shorthand attributes', null, true);
+                    // Allow too many shorthands
+                    $_indexed_attr[] = $mixed;
+                    //$compiler->trigger_template_error('too many shorthand attributes', null, true);
                 }
                 // named attribute
             } else {


### PR DESCRIPTION
JulienPalard mentioned this in Positional parameters ? #164 

We have had this patch for quite some time as we use positional parameters for many functions on Core Plus, (such as {date $model.created}).
